### PR TITLE
feat: 현재 채팅중인 유저의 수 헤더에 출력 기능 추가

### DIFF
--- a/front/src/router/index.js
+++ b/front/src/router/index.js
@@ -30,7 +30,8 @@ const routes = [
   {
     path: "/chat/:id",
     name: "ChatRoomView",
-    component: ChatRoomView
+    component: ChatRoomView,
+    props: true
   }
 ];
 

--- a/front/src/views/chat/chatRoom/ChatRoomHead.vue
+++ b/front/src/views/chat/chatRoom/ChatRoomHead.vue
@@ -6,12 +6,24 @@
             </v-btn>
             <v-toolbar-title>{{info.title}}</v-toolbar-title>
             <v-spacer></v-spacer>
+            <v-icon class="mr-1">mdi-account-multiple</v-icon>
+            <span v-text="info.userCount" class="mr-2">{{userCount}}</span>
         </v-row>
     </v-toolbar>
 </template>
 
 <script>
 export default {
-    props: ['info']
+    props: ['info'],
+    data() {
+        return {
+            userCount: 0
+        }
+    },
+    watch: {
+        info(newVal) {
+            this.userCount = newVal
+        }
+    }
 }
 </script>

--- a/front/src/views/chat/chatRoom/ChatRoomView.vue
+++ b/front/src/views/chat/chatRoom/ChatRoomView.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <chat-room-head :info="room"></chat-room-head>
-        <chat-room-body :info="room"></chat-room-body>
+        <chat-room-body :info="room" @reload="updateUserCount"></chat-room-body>
     </div>
 </template>
 
@@ -11,9 +11,11 @@ import ChatRoomBody from "./ChatRoomBody.vue"
 import axios from "axios";
 
 export default {
+    props: ['id'],
     data() {
         return {
-            room: {}
+            room: {},
+            pollingRoomData: null,
         }
     },
     created() {
@@ -21,8 +23,7 @@ export default {
     },
     methods: {
         findRoom() {
-            let roomId = this.$route.params.id
-            axios.get(`${location.protocol}//${location.host}/api/chat-room/${roomId}`)
+            axios.get(`${location.protocol}//${location.host}/api/chat-room/${this.id}`)
                 .then(response => {
                     this.room = response.data
                 })
@@ -30,6 +31,10 @@ export default {
                     console.log(error)
                 })
         },
+        updateUserCount(userCount) {
+            console.log(`update event : ${userCount}`)
+            this.room.userCount = userCount
+        }
     },
     components: {
         'chat-room-head': ChatRoomHead,

--- a/server/src/main/java/me/hwanse/chatserver/chat/ChatConnectInterceptor.java
+++ b/server/src/main/java/me/hwanse/chatserver/chat/ChatConnectInterceptor.java
@@ -2,7 +2,6 @@ package me.hwanse.chatserver.chat;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import me.hwanse.chatserver.chatroom.service.ChatRoomService;
 import me.hwanse.chatserver.chatroom.service.ChatVisitorService;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -11,7 +10,6 @@ import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.stereotype.Component;
 
-import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/server/src/main/java/me/hwanse/chatserver/chat/ChatController.java
+++ b/server/src/main/java/me/hwanse/chatserver/chat/ChatController.java
@@ -1,17 +1,18 @@
 package me.hwanse.chatserver.chat;
 
 import lombok.RequiredArgsConstructor;
+import me.hwanse.chatserver.chatroom.ChatRoom;
+import me.hwanse.chatserver.chatroom.service.ChatRoomService;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.socket.messaging.SessionConnectEvent;
-import org.springframework.web.socket.messaging.SessionSubscribeEvent;
 
 @Controller
 @RequiredArgsConstructor
 public class ChatController {
 
     private final SimpMessagingTemplate messagingTemplate;
+    private final ChatRoomService chatRoomService;
 
     @MessageMapping("/chat/join")
     public void joinInChat(ChatMessage chatMessage) {
@@ -23,8 +24,10 @@ public class ChatController {
         messagingTemplate.convertAndSend(getDestination(chatMessage.getRoomId()), chatMessage);
     }
 
-    @MessageMapping("/chat/leave")
-    public void leaveTheChat(ChatMessage chatMessage) {
+    @MessageMapping("/chat/monitoring")
+    public void monitoringRoom(ChatMessage chatMessage) {
+        ChatRoom chatRoom = chatRoomService.findChatRoomById(chatMessage.getRoomId());
+        chatMessage.setUserCount(chatRoom.getUserCount());
         messagingTemplate.convertAndSend(getDestination(chatMessage.getRoomId()), chatMessage);
     }
 

--- a/server/src/main/java/me/hwanse/chatserver/chat/ChatMessage.java
+++ b/server/src/main/java/me/hwanse/chatserver/chat/ChatMessage.java
@@ -13,6 +13,8 @@ public class ChatMessage {
 
     private String sender;
 
+    private int userCount;
+
     private MessageType messageType;
 
 }

--- a/server/src/main/java/me/hwanse/chatserver/chat/MessageType.java
+++ b/server/src/main/java/me/hwanse/chatserver/chat/MessageType.java
@@ -1,5 +1,5 @@
 package me.hwanse.chatserver.chat;
 
 public enum MessageType {
-    JOIN, TALK, LEAVE
+    JOIN, TALK, MONITOR
 }


### PR DESCRIPTION
- Front - Server 통신 메세지 타입별 분기 처리 추가
- Monitoring 전용 메세지일 경우에만 UI 헤더의 userCount 를 변경