### PR TITLE
refactor: modifty chat room create event

### DIFF
--- a/front/src/views/chat/chatList/ChatListBody.vue
+++ b/front/src/views/chat/chatList/ChatListBody.vue
@@ -8,7 +8,7 @@
             <ChatCreateButton v-on:@click="showDialog"/>
         </v-card>
 
-        <ChatRoomCreateDialog :show="showCreateDialog" v-on:@cancel="hideDialog"/>
+        <ChatRoomCreateDialog :show="showCreateDialog" v-on:@create="addChatRoom" v-on:@cancel="hideDialog"/>
     </div>
 </template>
 
@@ -48,6 +48,10 @@ export default {
         },
         hideDialog() {
             this.showCreateDialog = false
+        },
+        addChatRoom(item) {
+            this.chatList.unshift(item)
+            this.hideDialog()
         }
     }
 }

--- a/front/src/views/chat/chatList/parts/ChatRoomCreateDialog.vue
+++ b/front/src/views/chat/chatList/parts/ChatRoomCreateDialog.vue
@@ -40,11 +40,15 @@ export default {
             this.$emit("@cancel")
         },
         create() {
+            if (!this.title.trim()) return
+
             axios.post(`${location.protocol}//${location.host}/api/chat-room`, 
                         JSON.stringify({title : this.title}),
-                        { headers : {"Content-Type" : "application/json"}}
-                 )
-                 .then(() => this.$router.go())
+                        { headers : {"Content-Type" : "application/json"}})
+                 .then(response => {
+                    this.title = ''
+                    this.$emit("@create", response.data)
+                 })
                  .catch(reason => console.log(reason))
         }
     },

--- a/front/tests/unit/views/chat/chatList/parts/ChatRoomCreateDialog.spec.js
+++ b/front/tests/unit/views/chat/chatList/parts/ChatRoomCreateDialog.spec.js
@@ -20,9 +20,18 @@ describe("test ChatRoomCreateDialog", () => {
     
     test("emit @cancel event when click cancel button", async () => {
         wrapper.vm.$emit("@cancel")
+        
         await wrapper.findAll("v-btn-stub").at(0).trigger("click")
+
         expect(wrapper.emitted("@cancel")).toBeTruthy()  
-        expect(wrapper.vm.title).toBe("")
+    })
+
+    test("emit @create event when click create button", async () => {
+        wrapper.vm.$emit("@create")
+
+        await wrapper.findAll("v-btn-stub").at(1).trigger("click")
+
+        expect(wrapper.emitted("@create")).toBeTruthy()
     })
 
 })


### PR DESCRIPTION
- 채팅방 생성 시 페이지 리로드 처리하던 부분을 ux 개선을 위해 생성된 데이터를 chatList 첫번째 요소에 추가하도록 변경
- create 이벤트 테스트 코드 추가