### PR TITLE
refactor: 서버단 유저가 채팅방을 나갔을 경우의 테스트 코드 추가, 채팅방 컴포넌트 리팩토링

### DIFF
--- a/front/src/views/chat/chatRoom/ChatRoomBody.vue
+++ b/front/src/views/chat/chatRoom/ChatRoomBody.vue
@@ -3,31 +3,71 @@
         <ChatInputNicknameDialog :isInputNickname="noInputNickname" v-on:@click="inputNickname"/>
 
         <v-card>
-            <ChatTabs :roomId="info.id" :inputNickname="nickname" />
+            <ChatTabs :roomId="info.id" :inputNickname="nickname" :bus="bus" :stompClient="stompClient"/>
         </v-card>
     </div>
 </template>
 
 <script>
+import Vue from "vue"
+import SockJS from "sockjs-client"
+import Stomp from "webstomp-client"
 import ChatInputNicknameDialog from "./parts/ChatInputNicknameDialog.vue"
 import ChatTabs from "./parts/ChatTabs.vue"
-
 
 export default {
     props: ['info'],
     data() {
         return {
+            bus: new Vue(),
+            websocket: null,
+            stompClient: null,
             nickname: '',
             noInputNickname: true,
         }
     },
     methods: {
-        inputNickname(nickname) {
+        async inputNickname(nickname) {
             if (!nickname.trim()) return
 
             this.noInputNickname = false
             this.nickname = nickname
+
+            this.websocket = new SockJS(`${location.protocol}//${location.host}/ws/chat`)
+            // let options = {debug: false, protocols: Stomp.VERSIONS.supportedProtocols()};
+            this.stompClient = Stomp.over(this.websocket)
+            await this.stompClient.connect({}, this.onConnected, this.onConnectError)
         },
+        onConnected() {
+            this.bindSessionId()
+            this.stompClient.subscribe(`/sub/chat-room/${this.info.id}`, response => this.bus.$emit("join", response))
+            this.stompClient.subscribe(`/user/${this.bus.$data.mySessionId}/sub/chat-room/${this.info.id}/voice`, response => this.bus.$emit("signalling", response))
+            this.stompClient.subscribe(`/sub/chat-room/${this.info.id}/leave`, response => this.bus.$emit("leave", response))
+            window.addEventListener("beforeunload", this.closeEvent)
+
+            let data = {
+                roomId: this.info.id,
+                message: "JOIN",
+                sender: this.nickname,
+                messageType: "JOIN"
+            } 
+            this.stompClient.send("/pub/chat/join", JSON.stringify(data))
+        },
+        onConnectError(error) {
+            console.log("stomp connect error : ", error)
+        },
+        bindSessionId() {
+            let regex = /\/ws\/chat\/[0-9]+\/(\w+)\.*/g
+            let result = regex.exec(this.websocket._transport.url)
+            if (result) {
+                this.bus.$data.mySessionId = result[1] ? result[1] : null
+            }
+        },
+        closeEvent(event) {
+            event.preventDefault()
+            this.stompClient.disconnect()
+            this.websocket.close()
+        } 
     },
     components: {
         ChatInputNicknameDialog,

--- a/front/src/views/chat/chatRoom/parts/ChatTabs.vue
+++ b/front/src/views/chat/chatRoom/parts/ChatTabs.vue
@@ -13,11 +13,11 @@
          -->
         <v-tab-item :key="1" eager>
             <div class="voice-container">
-                <ChatVoiceComponent :roomId="roomId" :inputNickname="inputNickname" />
+                <ChatVoiceComponent :roomId="roomId" :inputNickname="inputNickname" :bus="bus" :stompClient="stompClient"/>
             </div>
         </v-tab-item>
         <v-tab-item :key="2" eager>
-            <ChatTextMessageComponent :roomId="roomId" :inputNickname="inputNickname" />
+            <ChatTextMessageComponent :roomId="roomId" :inputNickname="inputNickname" :bus="bus" :stompClient="stompClient"/>
         </v-tab-item>
     </v-tabs>
 </template>
@@ -27,7 +27,7 @@ import ChatTextMessageComponent from "./ChatTextMessageComponent.vue"
 import ChatVoiceComponent from "./ChatVoiceComponent.vue"
 
 export default {
-    props: ["roomId", "inputNickname"],
+    props: ["roomId", "inputNickname", "bus", "stompClient"],
     watch: {
         inputNickname(nickname) {
             this.inputNickname = nickname

--- a/server/src/main/java/me/hwanse/chatserver/chat/event/ChatSocketDisconnectEvent.java
+++ b/server/src/main/java/me/hwanse/chatserver/chat/event/ChatSocketDisconnectEvent.java
@@ -1,4 +1,4 @@
-package me.hwanse.chatserver.chat;
+package me.hwanse.chatserver.chat.event;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,8 +16,7 @@ public class ChatSocketDisconnectEvent implements ApplicationListener<SessionDis
 
     @Override
     public void onApplicationEvent(SessionDisconnectEvent event) {
-        String sessionId = event.getSessionId();
-        chatVisitorService.leaveChatVisitor(sessionId);
+        chatVisitorService.leaveChatVisitor(event.getSessionId());
     }
 
 }

--- a/server/src/main/java/me/hwanse/chatserver/chat/event/ChatSocketSubscribeEvent.java
+++ b/server/src/main/java/me/hwanse/chatserver/chat/event/ChatSocketSubscribeEvent.java
@@ -1,0 +1,39 @@
+package me.hwanse.chatserver.chat.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.hwanse.chatserver.chatroom.service.ChatVisitorService;
+import org.springframework.context.ApplicationListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatSocketSubscribeEvent implements ApplicationListener<SessionSubscribeEvent> {
+
+    private final ChatVisitorService chatVisitorService;
+
+    @Override
+    public void onApplicationEvent(SessionSubscribeEvent event) {
+        StompHeaderAccessor header = StompHeaderAccessor.wrap(event.getMessage());
+        long roomId = getRoomId(header.getDestination());
+
+        if (roomId > 0) {
+            chatVisitorService.addChatVisitor(roomId, header.getSessionId());
+        }
+    }
+
+    private long getRoomId(String destination) {
+        Pattern pattern = Pattern.compile(".*/sub/chat-room/([0-9]+).*$");
+        Matcher matcher = pattern.matcher(destination);
+        if (matcher.matches()) {
+            return Long.parseLong(matcher.group(1));
+        }
+        return -1;
+    }
+}

--- a/server/src/main/java/me/hwanse/chatserver/config/StompWebSocketConfig.java
+++ b/server/src/main/java/me/hwanse/chatserver/config/StompWebSocketConfig.java
@@ -16,8 +16,6 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @EnableWebSocketMessageBroker
 public class StompWebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
-    private final ChatConnectInterceptor connectInterceptor;
-
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws/chat").setAllowedOriginPatterns("*").withSockJS();
@@ -27,11 +25,6 @@ public class StompWebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.setApplicationDestinationPrefixes("/pub");  // spring 의 in-memory broker 를 활용하며 prefix 로 /pub 을 셋팅
         registry.enableSimpleBroker("/sub", "/user");
-    }
-
-    @Override
-    public void configureClientInboundChannel(ChannelRegistration registration) {
-        registration.interceptors(connectInterceptor);
     }
 
 }


### PR DESCRIPTION
- 유저가 브라우저를 종료했을 경우 특정 채팅방 나가기, 접속중이던 전체 채팅방 나가기  테스트 코드 수정
- subscribe, disconnect 핸들러를 interceptor 에서 eventListener 로 처리하도록 변경
- 프론트단 채팅방 컴포넌트 리팩토링 및 session Disconnect 처리 이슈 개선
  - 기존에 TextChat 컴포넌트, VoiceChat 컴포넌트로 나누어 각각 웹 소켓을  열고 connection을 유지했기 때문에 유저 한명당 2개의 웹소켓을 열었기 때문에 서버에서 1명당 2개의 세션을 관리하고 있었던 현상
  - 따라서 채팅방 Body 컴포넌트에서 웹 소켓을 한번 오픈하고 하위 Text/Voice Chat 컴포넌트에서 eventBus 를 통해 websocket, stomp 클라이언트 객체를 공유해 재사용하도록 리팩토링